### PR TITLE
bug 1 fixed- dropping labels

### DIFF
--- a/drag-drop-complete-2/js/main.js
+++ b/drag-drop-complete-2/js/main.js
@@ -19,6 +19,13 @@ function dragOver(event) {
 
 function drop(event) {
     event.preventDefault();
+
+    //checks that there is a label inside the drop zone already, if label is already dropped it will 'return back'
+    if(this.querySelector(".label")) {
+    console.log("This zone has a label");
+    return;
+    }
+
     this.appendChild(currentDraggedElement);
     currentDraggedElement = null;
 }


### PR DESCRIPTION
in this commit the bug 1 fix issue that entailed the labels being able to drop in the same drop zone were fixed- this was fixed by changing the if and this statements in the drop event. the this.querySelector(".label" checks if a label has already been dropped and if yes the clicked label returns back to the label menu.